### PR TITLE
Change angular version in bower.json file for resolution.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,6 +15,6 @@
     "angular-mocks": "~1.3.7"
   },
   "resolutions": {
-    "angular": "1.3.8"
+    "angular": "1.2.28"
   }
 }


### PR DESCRIPTION
Previous choice, 1.3.8, was causing invite page to break due to infinite digest loop. I think this was as a result of the angular-animate.