### PR TITLE
Students do not need to click twice to submit interest in an opportunity.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,5 @@ There should be four tabs open:
 
 ### Run
 In a fifth terminal window, navigate to `jobquery-client/test/E2E/conf.js` and enter `protractor conf.js` to run tests.
+
+Tests currently complete in around 30 seconds.

--- a/public/js/users/subroutes/opportunities/controllers/UsersOpportunitiesDetailCtrl.js
+++ b/public/js/users/subroutes/opportunities/controllers/UsersOpportunitiesDetailCtrl.js
@@ -98,6 +98,9 @@ app.controller('UsersOpportunitiesDetailCtrl',
     }
   };
 
+  // Not currently in-use. The submit button is commented out in the template,
+  // because clicking on the interest is enough. If there were employer questions in-play
+  // students could use this button to submit both the interest and their answers
   $scope.submit = function() {
     $scope.submitText = 'Submitting...';
     $scope.pendingRequests++;

--- a/public/js/users/subroutes/opportunities/controllers/UsersOpportunitiesDetailCtrl.js
+++ b/public/js/users/subroutes/opportunities/controllers/UsersOpportunitiesDetailCtrl.js
@@ -98,9 +98,8 @@ app.controller('UsersOpportunitiesDetailCtrl',
     }
   };
 
-  // Not currently in-use. The submit button is commented out in the template,
-  // because clicking on the interest is enough. If there were employer questions in-play
-  // students could use this button to submit both the interest and their answers
+  // Not currently in-use. The "Submit Preferences" button is commented out in the template,
+  // because clicking on the interest is enough. There are currently no employer questions to answer.
   $scope.submit = function() {
     $scope.submitText = 'Submitting...';
     $scope.pendingRequests++;

--- a/public/js/users/subroutes/opportunities/templates/detail.tpl.html
+++ b/public/js/users/subroutes/opportunities/templates/detail.tpl.html
@@ -138,9 +138,9 @@
                     <td><textarea type="text" size="40" ng-model="answers[question.index].answer"></textarea></td>
                 </tr>
             </table>
-            <div class="formbox-footer">
+            <!-- <div class="formbox-footer">
                 <input class="content-button" type="submit" value="{{submitText}}" ng-disabled="pendingRequest === 0">
-            </div>
+            </div> -->
         </form>
     </div>
 

--- a/test/E2E/Admin/matchGrid.js
+++ b/test/E2E/Admin/matchGrid.js
@@ -92,7 +92,7 @@ describe('Match grid', function() {
           });
       });
   
-    // // Navigate to job B.
+    // Navigate to job B.
     var opportunities = element(by.css('div#sidebar-opportunities'))
     opportunities.click();
 
@@ -102,18 +102,18 @@ describe('Match grid', function() {
 
     var matchGridButton = element(by.buttonText('Show Match Grid'));
 
-    // // Match grid should be hidden
+    // Match grid should be hidden
     jobBMatches = element.all(by.repeater('user in attending | filter:ExcludeAccepted() | orderBy:sorter:reverse'));
     expect( jobBMatches.count() ).toBe(0);
 
-    // // The match grid button should be enabled, bc it hasn't been clicked yet
+    // The match grid button should be enabled, bc it hasn't been clicked yet
     expect( matchGridButton.isEnabled() ).toBe(true);
-    // // Show match grid for job B.
+    // Show match grid for job B.
     matchGridButton.click();
-    // // Now button should be disabled an match grid showing
+    // Now button should be disabled an match grid showing
     expect( matchGridButton.isEnabled() ).toBe(false);
 
-    // // The match grid should be showing
+    // The match grid should be showing
     jobBMatches = element.all(by.repeater('user in attending | filter:ExcludeAccepted() | orderBy:sorter:reverse'));
     expect( jobBMatches.count() ).not.toBe(0);
 

--- a/test/E2E/User/SubmitInterest.js
+++ b/test/E2E/User/SubmitInterest.js
@@ -1,6 +1,9 @@
 var userLogin = require('../privateInfo.js').user;
 
 describe('Submit interest', function() {
+  var oldInterest;
+  var newInterest;
+
   it('should login as a user', function() {
     browser.get('http://localhost:8000/login');
     expect( element(by.css('div.login-box')).isPresent() ).toBe(true);
@@ -14,6 +17,14 @@ describe('Submit interest', function() {
     var opportunities = element(by.css('div#sidebar-opportunities'))
     browser.sleep(1000);
     opportunities.click();
+
+    // get the number rating
+    element(by.css('body > div.content-container > div.ng-scope > div > ui-view > div > div:nth-child(2) > div > table > tbody > tr:nth-child(1) > td:nth-child(4) > span.tablebox-important.ng-binding'))
+      .getText()
+        .then(function(selection) {
+          oldInterest = selection;
+          console.log('before: ', oldInterest);
+        });
 
     // click on the first company
     var apollo = element(by.cssContainingText('a.ng-binding', 'Apollo Lightspeed'));
@@ -53,6 +64,9 @@ describe('Submit interest', function() {
               afterSelection = text;
               box.click();
               clicked = true;
+
+              // translate the new selection to a number
+              newInterest = translateInterestIntoNumber(afterSelection);
             }
           });
       })
@@ -71,8 +85,17 @@ describe('Submit interest', function() {
     
   it('should update the opportunity interest on the opportunities page', function() {
     // navigate back to opportunities
-    // expect your interest for that position to be the number selected
-    expect(expecation).to.be(equal);
+    element(by.css('div#sidebar-opportunities')).click();
+    expect( browser.getCurrentUrl() ).toBe( 'http://localhost:8000/users/opportunities' );
+
+    // get the number rating
+    element(by.css('body > div.content-container > div.ng-scope > div > ui-view > div > div:nth-child(2) > div > table > tbody > tr:nth-child(1) > td:nth-child(4) > span.tablebox-important.ng-binding'))
+      .getText()
+        .then(function(number) {
+          // expect your interest for that position to be the number selected
+          expect(number).not.toBe(oldInterest);
+          expect(number).toBe(newInterest);
+        });
   });
 
   xit('should still have the interest when navigating back to the opportunity for a second time', function() {
@@ -82,3 +105,18 @@ describe('Submit interest', function() {
   });
 
 });
+
+var translateInterestIntoNumber = function(interestText) {
+  var cases = {
+    1: /NONE/,
+    2: /LOW/,
+    3: /MIS\//,
+    4: /VERY/
+  };
+
+  for(var key in cases) {
+    if( interestText.match(cases[key]) !== null ) {
+      return key;
+    }
+  }
+};

--- a/test/E2E/User/SubmitInterest.js
+++ b/test/E2E/User/SubmitInterest.js
@@ -1,0 +1,16 @@
+var userLogin = require('../privateInfo.js').user;
+
+describe('Submit interest', function() {
+  it('should login as a user', function() {
+    browser.get('http://localhost:8000/login');
+    expect( element(by.css('div.login-box')).isPresent() ).toBe(true);
+    element(by.model('email')).sendKeys(userLogin[0]);
+    element(by.model('password')).sendKeys(userLogin[1]);
+    element(by.css('input.login-button')).click();
+    expect( browser.getCurrentUrl() ).toBe( 'http://localhost:8000/users/dashboard' );
+  });
+
+  xit('should click the number 2 and submit without a second button', function() {
+    
+  });
+});

--- a/test/E2E/User/SubmitInterest.js
+++ b/test/E2E/User/SubmitInterest.js
@@ -23,8 +23,25 @@ describe('Submit interest', function() {
     expect( browser.getCurrentUrl() ).toBe( 'http://localhost:8000/users/opportunities/53b1ea816ecb92340e865aa6' );
   });
 
-  xit('should submit a interest', function() {
+  it('should submit a interest', function() {
+    var selection;
+
     // click on an interest that is different than the interest already selected
+    // get current interest selection
+    element(by.css('div.dashbox-icon.ng-scope.dashbox-icon-active'))
+      .then(function(selectedInterest) {
+        if( selectedInterest ) {
+          selectedInterest.getText()
+            .then(function(text) {
+              selection = text;
+              console.log('selection: ', selection);
+            });
+        } else {
+          selection = undefined;
+        }
+
+      });
+
     // navigate back to opportunities
 
     // expect your interest for that position to be the number selected

--- a/test/E2E/User/SubmitInterest.js
+++ b/test/E2E/User/SubmitInterest.js
@@ -49,13 +49,12 @@ describe('Submit interest', function() {
           .then(function(text) {
             if(text !== beforeSelection) {
               afterSelection = text;
+              box.click();
             }
           })
       })
       .then(function() {
         expect(beforeSelection).not.toBe(afterSelection);
-        console.log('before', beforeSelection);
-        console.log('after', afterSelection);
       });
       
       

--- a/test/E2E/User/SubmitInterest.js
+++ b/test/E2E/User/SubmitInterest.js
@@ -11,17 +11,26 @@ describe('Submit interest', function() {
   });
 
   it('should navigate to an opportunity', function() {
-    // click on opportunities
-    // click on the first company
+    var opportunities = element(by.css('div#sidebar-opportunities'))
+    browser.sleep(1000);
+    opportunities.click();
 
-  it('should submit a interest', function() {
+    // click on the first company
+    var apollo = element(by.cssContainingText('a.ng-binding', 'Apollo Lightspeed'));
+    browser.sleep(1000);
+    apollo.click();
+    
+    expect( browser.getCurrentUrl() ).toBe( 'http://localhost:8000/users/opportunities/53b1ea816ecb92340e865aa6' );
+  });
+
+  xit('should submit a interest', function() {
     // click on an interest that is different than the interest already selected
     // navigate back to opportunities
 
     // expect your interest for that position to be the number selected
   });
 
-  it('should still have the interest when navigating back to the opportunity for a second time', function() {
+  xit('should still have the interest when navigating back to the opportunity for a second time', function() {
     // click on same first company
     // expect correct number to be highlighted
     expect(expecation).to.be(equal);

--- a/test/E2E/User/SubmitInterest.js
+++ b/test/E2E/User/SubmitInterest.js
@@ -5,23 +5,26 @@ describe('Submit interest', function() {
   var newInterest;
 
   it('should login as a user', function() {
-    browser.get('http://localhost:8000/login');
-    expect( element(by.css('div.login-box')).isPresent() ).toBe(true);
-    element(by.model('email')).sendKeys(userLogin[0]);
-    element(by.model('password')).sendKeys(userLogin[1]);
+    browser.get( 'http://localhost:8000/login' );
+    expect( element(by.css('div.login-box')).isPresent() ).toBe( true );
+    element(by.model('email')).sendKeys( userLogin[0] );
+    element(by.model('password')).sendKeys( userLogin[1] );
     element(by.css('input.login-button')).click();
     expect( browser.getCurrentUrl() ).toBe( 'http://localhost:8000/users/dashboard' );
   });
 
   it('should navigate to an opportunity', function() {
-    var opportunities = element(by.css('div#sidebar-opportunities'))
+    var opportunities = element(by.css('div#sidebar-opportunities'));
+    // wait for page to load
     browser.sleep(1000);
     opportunities.click();
 
-    // get the number rating
+    // get the number current number rating of the first job
     element(by.css('body > div.content-container > div.ng-scope > div > ui-view > div > div:nth-child(2) > div > table > tbody > tr:nth-child(1) > td:nth-child(4) > span.tablebox-important.ng-binding'))
       .getText()
         .then(function(selection) {
+          // In the console, the element's text appears to have a space in front of it: ' 2' not '2'
+          // Selection, however, only returns the number: '2'
           oldInterest = selection;
         });
 
@@ -42,7 +45,7 @@ describe('Submit interest', function() {
     element(by.css('div.dashbox-icon-active'))
       .then(function(selectedInterest) {
         // if there is an interest already
-        if( selectedInterest ) {
+        if( selectedInterest.isPresent() ) {
           selectedInterest.getText()
             .then(function(text) {
               beforeSelection = text;
@@ -55,12 +58,17 @@ describe('Submit interest', function() {
     
     // get all of the non-selected options
     element.all(by.css('div.dashbox-icon.ng-scope'))
+      // for each of them
       .each(function(box) {
+        // get the text
         box.getText()
           .then(function(text) {
             // if the interest is not the same as the one already selected
+            // clicked === false effectively breaks this loop, 
+            // otherwise the selection would always go to the end of the ElementArrayFinder
             if(text !== beforeSelection && clicked === false) {
               afterSelection = text;
+              // make a new interest selection
               box.click();
               clicked = true;
 
@@ -71,15 +79,14 @@ describe('Submit interest', function() {
       })
       .then(function() {
         // confirm we're not just selecting the same interest
-        expect(beforeSelection).not.toBe(afterSelection);
+        expect( beforeSelection ).not.toBe( afterSelection );
 
         // look for the active box to have changed css styles
         element(by.css('div.dashbox-icon-active'))
           .then(function(selectedInterest) {
-            expect(selectedInterest.getText()).toBe(afterSelection);
+            expect( selectedInterest.getText() ).toBe( afterSelection );
           });
       });
-      
   });
     
   it('should update the opportunity interest on the opportunities page', function() {
@@ -91,9 +98,9 @@ describe('Submit interest', function() {
     element(by.css('body > div.content-container > div.ng-scope > div > ui-view > div > div:nth-child(2) > div > table > tbody > tr:nth-child(1) > td:nth-child(4) > span.tablebox-important.ng-binding'))
       .getText()
         .then(function(number) {
-          expect(number).not.toBe(oldInterest);
+          expect( number ).not.toBe( oldInterest );
           // expect your interest for that position to be the number selected
-          expect(number).toBe(newInterest);
+          expect( number ).toBe( newInterest );
         });
   });
 
@@ -104,11 +111,12 @@ describe('Submit interest', function() {
     apollo.click();
     expect( browser.getCurrentUrl() ).toBe( 'http://localhost:8000/users/opportunities/53b1ea816ecb92340e865aa6' );
 
-    // expect correct number to be highlighted
+    // get the highlighted interest box
     element(by.css('div.dashbox-icon-active'))
       .then(function(selectedInterest) {
         selectedInterest.getText()
           .then(function(text) {
+            // expect correct number to be highlighted
             expect( translateInterestIntoNumber(text) ).toBe( newInterest );
           })
       });     

--- a/test/E2E/User/SubmitInterest.js
+++ b/test/E2E/User/SubmitInterest.js
@@ -23,7 +23,6 @@ describe('Submit interest', function() {
       .getText()
         .then(function(selection) {
           oldInterest = selection;
-          console.log('before: ', oldInterest);
         });
 
     // click on the first company
@@ -92,16 +91,27 @@ describe('Submit interest', function() {
     element(by.css('body > div.content-container > div.ng-scope > div > ui-view > div > div:nth-child(2) > div > table > tbody > tr:nth-child(1) > td:nth-child(4) > span.tablebox-important.ng-binding'))
       .getText()
         .then(function(number) {
-          // expect your interest for that position to be the number selected
           expect(number).not.toBe(oldInterest);
+          // expect your interest for that position to be the number selected
           expect(number).toBe(newInterest);
         });
   });
 
-  xit('should still have the interest when navigating back to the opportunity for a second time', function() {
+  it('should still have the interest when navigating back to the opportunity for a second time', function() {
     // click on same first company
+    var apollo = element(by.cssContainingText('a.ng-binding', 'Apollo Lightspeed'));
+    browser.sleep(1000);
+    apollo.click();
+    expect( browser.getCurrentUrl() ).toBe( 'http://localhost:8000/users/opportunities/53b1ea816ecb92340e865aa6' );
+
     // expect correct number to be highlighted
-    expect(expecation).to.be(equal);
+    element(by.css('div.dashbox-icon-active'))
+      .then(function(selectedInterest) {
+        selectedInterest.getText()
+          .then(function(text) {
+            expect( translateInterestIntoNumber(text) ).toBe( newInterest );
+          })
+      });     
   });
 
 });

--- a/test/E2E/User/SubmitInterest.js
+++ b/test/E2E/User/SubmitInterest.js
@@ -10,7 +10,21 @@ describe('Submit interest', function() {
     expect( browser.getCurrentUrl() ).toBe( 'http://localhost:8000/users/dashboard' );
   });
 
-  xit('should click the number 2 and submit without a second button', function() {
-    
+  it('should navigate to an opportunity', function() {
+    // click on opportunities
+    // click on the first company
+
+  it('should submit a interest', function() {
+    // click on an interest that is different than the interest already selected
+    // navigate back to opportunities
+
+    // expect your interest for that position to be the number selected
   });
+
+  it('should still have the interest when navigating back to the opportunity for a second time', function() {
+    // click on same first company
+    // expect correct number to be highlighted
+    expect(expecation).to.be(equal);
+  });
+
 });

--- a/test/E2E/User/SubmitInterest.js
+++ b/test/E2E/User/SubmitInterest.js
@@ -26,10 +26,12 @@ describe('Submit interest', function() {
   it('should submit a interest', function() {
     var beforeSelection;
     var afterSelection;
+    var clicked = false;
 
     // get current interest selection
     element(by.css('div.dashbox-icon-active'))
       .then(function(selectedInterest) {
+        // if there is an interest already
         if( selectedInterest ) {
           selectedInterest.getText()
             .then(function(text) {
@@ -41,31 +43,36 @@ describe('Submit interest', function() {
         }
       });
     
-
-    // click on an interest that is different than the interest already selected
+    // get all of the non-selected options
     element.all(by.css('div.dashbox-icon.ng-scope'))
       .each(function(box) {
         box.getText()
           .then(function(text) {
-            if(text !== beforeSelection) {
+            // if the interest is not the same as the one already selected
+            if(text !== beforeSelection && clicked === false) {
               afterSelection = text;
               box.click();
+              clicked = true;
             }
-          })
+          });
       })
       .then(function() {
+        // confirm we're not just selecting the same interest
         expect(beforeSelection).not.toBe(afterSelection);
+
+        // look for the active box to have changed css styles
+        element(by.css('div.dashbox-icon-active'))
+          .then(function(selectedInterest) {
+            expect(selectedInterest.getText()).toBe(afterSelection);
+          });
       });
       
-      
-          
-
-
-
-
+  });
+    
+  it('should update the opportunity interest on the opportunities page', function() {
     // navigate back to opportunities
-
     // expect your interest for that position to be the number selected
+    expect(expecation).to.be(equal);
   });
 
   xit('should still have the interest when navigating back to the opportunity for a second time', function() {

--- a/test/E2E/User/SubmitInterest.js
+++ b/test/E2E/User/SubmitInterest.js
@@ -24,23 +24,45 @@ describe('Submit interest', function() {
   });
 
   it('should submit a interest', function() {
-    var selection;
+    var beforeSelection;
+    var afterSelection;
 
-    // click on an interest that is different than the interest already selected
     // get current interest selection
-    element(by.css('div.dashbox-icon.ng-scope.dashbox-icon-active'))
+    element(by.css('div.dashbox-icon-active'))
       .then(function(selectedInterest) {
         if( selectedInterest ) {
           selectedInterest.getText()
             .then(function(text) {
-              selection = text;
-              console.log('selection: ', selection);
+              beforeSelection = text;
             });
+        // no selection has been made yet
         } else {
-          selection = undefined;
+          beforeSelection = undefined;
         }
-
       });
+    
+
+    // click on an interest that is different than the interest already selected
+    element.all(by.css('div.dashbox-icon.ng-scope'))
+      .each(function(box) {
+        box.getText()
+          .then(function(text) {
+            if(text !== beforeSelection) {
+              afterSelection = text;
+            }
+          })
+      })
+      .then(function() {
+        expect(beforeSelection).not.toBe(afterSelection);
+        console.log('before', beforeSelection);
+        console.log('after', afterSelection);
+      });
+      
+      
+          
+
+
+
 
     // navigate back to opportunities
 

--- a/test/E2E/conf.js
+++ b/test/E2E/conf.js
@@ -1,7 +1,11 @@
 exports.config = {
   seleniumAddress: 'http://localhost:4444/wd/hub',
   specs: [
+    // Admin tests
     './Admin/adminLogin.js',
-    './Admin/matchGrid.js'
+    './Admin/matchGrid.js',
+
+    // User tests
+    './User/SubmitInterest.js'
   ]
 };


### PR DESCRIPTION
Previously: Students clicked on an interest, then clicked again on a "Submit Preferences" button.

![screen shot 2015-02-23 at 3 49 36 pm](https://cloud.githubusercontent.com/assets/8163408/6340398/bd0922e8-bb73-11e4-8a51-f896134e0468.png)

Interestingly, while in development, I found that clicking on the numbers themselves submit the interest, not just the button. So, I simply removed the button for future use.

![screen shot 2015-02-23 at 3 56 29 pm](https://cloud.githubusercontent.com/assets/8163408/6340493/8f706f5c-bb74-11e4-876a-460552171bdb.png)

This change is accompanied by Protractor end-to-end tests.

In the future, there could be some text on the bottom saying, "Saving your interest" to provide user feedback.